### PR TITLE
III-3193 Prevent port 80 being appended to https redirect urls

### DIFF
--- a/src/OAuth/OAuthUrlHelper.php
+++ b/src/OAuth/OAuthUrlHelper.php
@@ -79,7 +79,7 @@ class OAuthUrlHelper
         // https://github.com/slimphp/Slim/blob/200c6143f15baa477601879b64ab2326847aac0b/Slim/Http/Uri.php#L825
         $uri = $request->getUri();
         $scheme = $uri->getScheme();
-        $authority = $uri->getAuthority();
-        return ($scheme !== '' ? $scheme . ':' : '') . ($authority ? '//' . $authority : '');
+        $host = $uri->getHost();
+        return ($scheme !== '' ? $scheme . ':' : '') . ($host ? '//' . $host : '');
     }
 }


### PR DESCRIPTION
getAuthority() includes the port number and is sometimes (incorrectly) 80 even if we're working over ssl. Since we will probably never have a base url with a non-standard port and/or basic http authentication in the url, we can just use getHost() instead.