### PR TITLE
Bug: Locale not provided causing app to crash

### DIFF
--- a/src/Infrastructure/Service/ExtractLocaleFromRequest.php
+++ b/src/Infrastructure/Service/ExtractLocaleFromRequest.php
@@ -7,12 +7,12 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class ExtractLocaleFromRequest
 {
-    public function __invoke(ServerRequestInterface $serverRequest): ?string
+    public function __invoke(ServerRequestInterface $serverRequest): string
     {
         $lang = $this->extractParameter($serverRequest);
 
         if (!in_array($lang, [Locale::DUTCH, Locale::FRENCH])) {
-            return null;
+            return Locale::DUTCH;
         }
 
         return $lang;

--- a/tests/Domain/Service/ExtractLocaleFromRequestTest.php
+++ b/tests/Domain/Service/ExtractLocaleFromRequestTest.php
@@ -32,21 +32,21 @@ class ExtractLocaleFromRequestTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_null_for_requests_with_no_locale()
+    public function it_returns_default_dutch_for_requests_with_no_locale()
     {
         $serverRequest = $this->prophesize(ServerRequestInterface::class);
         $serverRequest->getQueryParams()->willReturn([]);
 
         $extractLocaleFromRequest = new ExtractLocaleFromRequest();
         $result = $extractLocaleFromRequest->__invoke($serverRequest->reveal());
-        $this->assertEquals($result, null);
+        $this->assertEquals($result, Locale::DUTCH);
     }
 
     /**
      * @test
      */
 
-    public function it_returns_null_for_requests_with_invalid_locale()
+    public function it_returns_default_for_requests_with_invalid_locale()
     {
         $serverRequest = $this->prophesize(ServerRequestInterface::class);
         $serverRequest->getQueryParams()
@@ -58,7 +58,7 @@ class ExtractLocaleFromRequestTest extends TestCase
 
         $extractLocaleFromRequest = new ExtractLocaleFromRequest();
         $result = $extractLocaleFromRequest->__invoke($serverRequest->reveal());
-        $this->assertEquals($result, null);
+        $this->assertEquals($result, Locale::DUTCH);
     }
 
     public function validLocalesProvider()


### PR DESCRIPTION
### Changed
- return a default value from locale if none is provided