### PR TITLE
[DO NOT MERGE] Access tokens instead of id tokens

### DIFF
--- a/app/ActionServiceProvider.php
+++ b/app/ActionServiceProvider.php
@@ -166,6 +166,7 @@ final class ActionServiceProvider extends BaseServiceProvider
                         'scope' => 'openid email profile offline_access',
                         'persist_id_token' => true,
                         'persist_refresh_token' => true,
+                        'audience' => 'https://api.publiq.be',
                     ]
                 );
             }

--- a/src/Infrastructure/Service/LoginAuth0Adapter.php
+++ b/src/Infrastructure/Service/LoginAuth0Adapter.php
@@ -26,7 +26,7 @@ final class LoginAuth0Adapter implements LoginServiceInterface
 
     public function redirectToLogin(string $locale = Locale::DUTCH): ?ResponseInterface
     {
-        $this->auth0->login(null, null, ['locale' => $locale]);
+        $this->auth0->login(null, null, ['locale' => $locale, 'prompt' => 'login']);
         return null;
     }
 

--- a/src/Infrastructure/Service/LoginAuth0Adapter.php
+++ b/src/Infrastructure/Service/LoginAuth0Adapter.php
@@ -36,7 +36,7 @@ final class LoginAuth0Adapter implements LoginServiceInterface
     public function token(): ?string
     {
         try {
-            return $this->auth0->getIdToken();
+            return $this->auth0->getAccessToken();
         } catch (ApiException $e) {
             throw new UnSuccessfulAuthException();
         } catch (CoreException $e) {


### PR DESCRIPTION
### Changed

- JWT provider returns access tokens instead of id tokens, for easier testing of the access token tickets on UDB3

---

Note: This should not be merged! The JWT provider should keep returning ID tokens on acc/test/prod, to ensure backward compatibility in existing integrations. This change is just for easier local testing.