### PR TITLE
[III-5060] combine build and build artifact steps into one rake task

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,6 @@
 
 # Jenkins / deployment owners
 Gemfile* @willaerk @paulherbosch
-Jenkinsfile @willaerk @paulherbosch
+Jenkinsfile* @willaerk @paulherbosch
 Rakefile @willaerk @paulherbosch
 lib/ @willaerk @paulherbosch

--- a/Jenkinsfile.uitidv1
+++ b/Jenkinsfile.uitidv1
@@ -26,12 +26,15 @@ pipeline {
                         sh label: 'Install rubygems', script: 'bundle install --deployment'
                     }
                 }
-                stage('Build') {
-                    steps {
-                        sh label: 'Build binaries', script: 'bundle exec rake jwt-provider-uitidv1:build'
-                    }
-                }
-                stage('Build artifact') {
+                // stage('Build') {
+                //     steps {
+                //         sh label: 'Build binaries', script: 'bundle exec rake jwt-provider-uitidv1:build'
+                //     }
+                // }
+
+                // we need to combine build and build artifact because we checkout a tag.
+                // once checked out, the rake tasks no longer exist ...
+                stage('Build & Build artifact') {
                     steps {
                         sh label: 'Build artifact', script: "bundle exec rake jwt-provider-uitidv1:build_artifact ARTIFACT_VERSION=${env.ARTIFACT_VERSION}"
                         archiveArtifacts artifacts: "pkg/*${env.ARTIFACT_VERSION}*.deb", onlyIfSuccessful: true

--- a/lib/tasks/jwt-provider-uitidv1/build_artifact.rake
+++ b/lib/tasks/jwt-provider-uitidv1/build_artifact.rake
@@ -11,7 +11,10 @@ namespace 'jwt-provider-uitidv1' do
     license        = 'Apache-2.0'
     description    = 'JSON Web Token provider for UiTDatabank 3'
     source         = 'https://github.com/cultuurnet/jwt-provider'
-  
+ 
+    system('git checkout refs/tags/uitidv1') or exit 1
+    system('composer2 install --no-dev --ignore-platform-reqs --prefer-dist --optimize-autoloader') or exit 1
+ 
     FileUtils.mkdir_p('pkg')
     FileUtils.touch('config.yml')
   


### PR DESCRIPTION
By switching to a tag, the rake tasks disappear from the checked out repo.
A running rake task gets loaded into memory and seems to complete it's commands just fine...

https://jenkins.publiq.be/job/UiTdatabank%20JWT%20provider%20UiTIDv1/1/console

```
...
[Pipeline] sh (Build binaries)
+ bundle exec rake jwt-provider-uitidv1:build
Previous HEAD position was b814bd9... Merge pull request #111 from cultuurnet/feature/III-5060
HEAD is now at d8da923... Merge pull request #17 from cultuurnet/bugfix/III-3193-fix-redirect
...
[Pipeline] sh (Build artifact)
+ bundle exec rake jwt-provider-uitidv1:build_artifact ARTIFACT_VERSION=2022.10.25.061834+sha.b814bd9
rake aborted!
No Rakefile found (looking for: rakefile, Rakefile, rakefile.rb, Rakefile.rb)
...
```