### PR TITLE
III-6082 Remove PHP 7.1, 7.2, 7.3 checks in the pipeline

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,4 +7,4 @@
 ### Fixed
 
 ---
-Ticket:
+Ticket: https://jira.publiq.be/browse/III-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.1', '7.2', '7.3', '7.4']
+                php-versions: ['7.4']
         name: PHP ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     cs:
         runs-on: ubuntu-latest
-        name: Code style
+        name: Code style (PHP 7.4)
         steps:
             - name: 📤 Checkout project
               uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
             - name: 🐘 Install PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.1
+                  php-version: 7.4
                   tools: composer
 
             - name: 📩 Cache Composer packages
@@ -73,7 +73,7 @@ jobs:
 
     phpstan:
       runs-on: ubuntu-latest
-      name: Static analysis
+      name: Static analysis (PHP 7.4)
       steps:
         - name: 📤 Checkout project
           uses: actions/checkout@v2
@@ -81,7 +81,7 @@ jobs:
         - name: 🐘 Install PHP
           uses: shivammathur/setup-php@v2
           with:
-            php-version: 7.1
+            php-version: 7.4
             tools: composer
 
         - name: 📩 Cache Composer packages


### PR DESCRIPTION
### Removed
I removed PHP 7.1, 7.2, 7.3 checks in the pipeline, because the servers all run on PHP 7.4 now.
This will make it easier to upgrade for the PHP8 upgrade as well, only having to support PHP 7.4.

---
Ticket: https://jira.publiq.be/browse/III-6082