### PR TITLE
III-6082 upgrade with rector to php7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.4']
+                php-versions: ['7.4', '8.0']
         name: PHP ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project
@@ -82,6 +82,64 @@ jobs:
           uses: shivammathur/setup-php@v2
           with:
             php-version: 7.4
+            tools: composer
+
+        - name: 📩 Cache Composer packages
+          id: composer-cache
+          uses: actions/cache@v2
+          with:
+            path: vendor
+            key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+            restore-keys: |
+              ${{ runner.os }}-php-
+
+        - name: 📦 Install dependencies
+          if: steps.composer-cache.outputs.cache-hit != 'true'
+          run: composer install --no-progress --no-suggest
+
+        - name: 🔍 Run static analysis
+          run: composer phpstan
+
+    cs-php80:
+      runs-on: ubuntu-latest
+      name: Code style (PHP 8.0)
+      steps:
+        - name: 📤 Checkout project
+          uses: actions/checkout@v2
+
+        - name: 🐘 Install PHP
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: 8.0
+            tools: composer
+
+        - name: 📩 Cache Composer packages
+          id: composer-cache
+          uses: actions/cache@v2
+          with:
+            path: vendor
+            key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+            restore-keys: |
+              ${{ runner.os }}-php-
+
+        - name: 📦 Install dependencies
+          if: steps.composer-cache.outputs.cache-hit != 'true'
+          run: composer install --no-progress --no-suggest
+
+        - name: ✨ Run code style check
+          run: composer cs
+
+    phpstan-php80:
+      runs-on: ubuntu-latest
+      name: Static analysis (PHP 8.0)
+      steps:
+        - name: 📤 Checkout project
+          uses: actions/checkout@v2
+
+        - name: 🐘 Install PHP
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: 8.0
             tools: composer
 
         - name: 📩 Cache Composer packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,10 @@ jobs:
 
     cs:
         runs-on: ubuntu-latest
-        name: Code style (PHP 7.4)
+        strategy:
+          matrix:
+            php-versions: [ '7.4', '8.0' ]
+        name: Code style (PHP ${{ matrix.php-versions }})
         steps:
             - name: 📤 Checkout project
               uses: actions/checkout@v2
@@ -52,7 +55,7 @@ jobs:
             - name: 🐘 Install PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.4
+                  php-version: ${{ matrix.php-versions }}
                   tools: composer
 
             - name: 📩 Cache Composer packages
@@ -73,7 +76,10 @@ jobs:
 
     phpstan:
       runs-on: ubuntu-latest
-      name: Static analysis (PHP 7.4)
+      strategy:
+        matrix:
+          php-versions: [ '7.4', '8.0' ]
+      name: Static analysis (PHP ${{ matrix.php-versions }})
       steps:
         - name: 📤 Checkout project
           uses: actions/checkout@v2
@@ -81,65 +87,7 @@ jobs:
         - name: 🐘 Install PHP
           uses: shivammathur/setup-php@v2
           with:
-            php-version: 7.4
-            tools: composer
-
-        - name: 📩 Cache Composer packages
-          id: composer-cache
-          uses: actions/cache@v2
-          with:
-            path: vendor
-            key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-            restore-keys: |
-              ${{ runner.os }}-php-
-
-        - name: 📦 Install dependencies
-          if: steps.composer-cache.outputs.cache-hit != 'true'
-          run: composer install --no-progress --no-suggest
-
-        - name: 🔍 Run static analysis
-          run: composer phpstan
-
-    cs-php80:
-      runs-on: ubuntu-latest
-      name: Code style (PHP 8.0)
-      steps:
-        - name: 📤 Checkout project
-          uses: actions/checkout@v2
-
-        - name: 🐘 Install PHP
-          uses: shivammathur/setup-php@v2
-          with:
-            php-version: 8.0
-            tools: composer
-
-        - name: 📩 Cache Composer packages
-          id: composer-cache
-          uses: actions/cache@v2
-          with:
-            path: vendor
-            key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-            restore-keys: |
-              ${{ runner.os }}-php-
-
-        - name: 📦 Install dependencies
-          if: steps.composer-cache.outputs.cache-hit != 'true'
-          run: composer install --no-progress --no-suggest
-
-        - name: ✨ Run code style check
-          run: composer cs
-
-    phpstan-php80:
-      runs-on: ubuntu-latest
-      name: Static analysis (PHP 8.0)
-      steps:
-        - name: 📤 Checkout project
-          uses: actions/checkout@v2
-
-        - name: 🐘 Install PHP
-          uses: shivammathur/setup-php@v2
-          with:
-            php-version: 8.0
+            php-version: ${{ matrix.php-versions }}
             tools: composer
 
         - name: 📩 Cache Composer packages

--- a/app/ActionServiceProvider.php
+++ b/app/ActionServiceProvider.php
@@ -49,7 +49,7 @@ final class ActionServiceProvider extends BaseServiceProvider
     {
         $this->addShared(
             RequestToken::class,
-            fn (): \CultuurNet\UDB3\JwtProvider\Domain\Action\RequestToken => new RequestToken(
+            fn (): RequestToken => new RequestToken(
                 $this->get(ExtractClientInformationFromRequest::class),
                 $this->get(LoginServiceInterface::class),
                 $this->get(ClientInformationRepositoryInterface::class),
@@ -59,7 +59,7 @@ final class ActionServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             Authorize::class,
-            fn (): \CultuurNet\UDB3\JwtProvider\Domain\Action\Authorize => new Authorize(
+            fn (): Authorize => new Authorize(
                 $this->get(LoginServiceInterface::class),
                 new GenerateAuthorizedDestinationUrl(),
                 $this->get(ResponseFactoryInterface::class),
@@ -69,7 +69,7 @@ final class ActionServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             RequestLogout::class,
-            fn (): \CultuurNet\UDB3\JwtProvider\Domain\Action\RequestLogout => new RequestLogout(
+            fn (): RequestLogout => new RequestLogout(
                 $this->get(ExtractClientInformationFromRequest::class),
                 $this->get(LogOutServiceInterface::class),
                 $this->get(ClientInformationRepositoryInterface::class)
@@ -78,7 +78,7 @@ final class ActionServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             LogOut::class,
-            fn (): \CultuurNet\UDB3\JwtProvider\Domain\Action\LogOut => new LogOut(
+            fn (): LogOut => new LogOut(
                 $this->get(ClientInformationRepositoryInterface::class),
                 $this->get(ResponseFactoryInterface::class)
             )
@@ -86,7 +86,7 @@ final class ActionServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             Refresh::class,
-            fn (): \CultuurNet\UDB3\JwtProvider\Domain\Action\Refresh => new Refresh(
+            fn (): Refresh => new Refresh(
                 $this->get(ResponseFactoryInterface::class),
                 $this->get(RefreshServiceInterface::class)
             )
@@ -94,7 +94,7 @@ final class ActionServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             LogOutServiceInterface::class,
-            fn (): \CultuurNet\UDB3\JwtProvider\Infrastructure\Service\LogOutAuth0Adapter => new LogOutAuth0Adapter(
+            fn (): LogOutAuth0Adapter => new LogOutAuth0Adapter(
                 $this->get(Auth0::class),
                 new Authentication(
                     [
@@ -113,19 +113,19 @@ final class ActionServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             ResponseFactoryInterface::class,
-            fn (): \CultuurNet\UDB3\JwtProvider\Infrastructure\Factory\SlimResponseFactory => new SlimResponseFactory()
+            fn (): SlimResponseFactory => new SlimResponseFactory()
         );
 
         $this->addShared(
             LoginServiceInterface::class,
-            fn (): \CultuurNet\UDB3\JwtProvider\Infrastructure\Service\LoginAuth0Adapter => new LoginAuth0Adapter(
+            fn (): LoginAuth0Adapter => new LoginAuth0Adapter(
                 $this->get(Auth0::class)
             )
         );
 
         $this->addShared(
             RefreshServiceInterface::class,
-            fn (): \CultuurNet\UDB3\JwtProvider\Infrastructure\Service\RefreshAuth0Adapter => new RefreshAuth0Adapter(
+            fn (): RefreshAuth0Adapter => new RefreshAuth0Adapter(
                 new Client(),
                 $this->parameter('auth0.client_id'),
                 $this->parameter('auth0.client_secret'),
@@ -135,7 +135,7 @@ final class ActionServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             Auth0::class,
-            fn (): \Auth0\SDK\Auth0 => new Auth0(
+            fn (): Auth0 => new Auth0(
                 [
                     'domain' => $this->parameter('auth0.domain'),
                     'clientId' => $this->parameter('auth0.client_id'),
@@ -152,7 +152,7 @@ final class ActionServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             IsAllowedRefreshToken::class,
-            fn (): \CultuurNet\UDB3\JwtProvider\Infrastructure\Service\IsAllowedRefreshToken => new IsAllowedRefreshToken(
+            fn (): IsAllowedRefreshToken => new IsAllowedRefreshToken(
                 $this->get(ConsumerReadRepositoryInterface::class),
                 (string)$this->parameter('auth0.allowed_refresh_permission')
             )
@@ -160,7 +160,7 @@ final class ActionServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             ClientInformationRepositoryInterface::class,
-            function (): \CultuurNet\UDB3\JwtProvider\Infrastructure\Repository\SessionClientInformation {
+            function (): SessionClientInformation {
                 $session = $this->get(Session::class);
                 $segment = $session->getSegment(ClientInformationRepositoryInterface::class);
                 return new SessionClientInformation(
@@ -171,7 +171,7 @@ final class ActionServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             ExtractClientInformationFromRequest::class,
-            fn (): \CultuurNet\UDB3\JwtProvider\Infrastructure\Service\ExtractClientInformationFromRequest => new ExtractClientInformationFromRequest(
+            fn (): ExtractClientInformationFromRequest => new ExtractClientInformationFromRequest(
                 new UriFactory(),
                 $this->get(ApiKeyReaderInterface::class),
                 $this->get(IsAllowedRefreshToken::class)

--- a/app/ActionServiceProvider.php
+++ b/app/ActionServiceProvider.php
@@ -49,140 +49,118 @@ final class ActionServiceProvider extends BaseServiceProvider
     {
         $this->addShared(
             RequestToken::class,
-            function () {
-                return new RequestToken(
-                    $this->get(ExtractClientInformationFromRequest::class),
-                    $this->get(LoginServiceInterface::class),
-                    $this->get(ClientInformationRepositoryInterface::class),
-                    $this->get(ExtractLocaleFromRequest::class)
-                );
-            }
+            fn (): \CultuurNet\UDB3\JwtProvider\Domain\Action\RequestToken => new RequestToken(
+                $this->get(ExtractClientInformationFromRequest::class),
+                $this->get(LoginServiceInterface::class),
+                $this->get(ClientInformationRepositoryInterface::class),
+                $this->get(ExtractLocaleFromRequest::class)
+            )
         );
 
         $this->addShared(
             Authorize::class,
-            function () {
-                return new Authorize(
-                    $this->get(LoginServiceInterface::class),
-                    new GenerateAuthorizedDestinationUrl(),
-                    $this->get(ResponseFactoryInterface::class),
-                    $this->get(ClientInformationRepositoryInterface::class)
-                );
-            }
+            fn (): \CultuurNet\UDB3\JwtProvider\Domain\Action\Authorize => new Authorize(
+                $this->get(LoginServiceInterface::class),
+                new GenerateAuthorizedDestinationUrl(),
+                $this->get(ResponseFactoryInterface::class),
+                $this->get(ClientInformationRepositoryInterface::class)
+            )
         );
 
         $this->addShared(
             RequestLogout::class,
-            function () {
-                return new RequestLogout(
-                    $this->get(ExtractClientInformationFromRequest::class),
-                    $this->get(LogOutServiceInterface::class),
-                    $this->get(ClientInformationRepositoryInterface::class)
-                );
-            }
+            fn (): \CultuurNet\UDB3\JwtProvider\Domain\Action\RequestLogout => new RequestLogout(
+                $this->get(ExtractClientInformationFromRequest::class),
+                $this->get(LogOutServiceInterface::class),
+                $this->get(ClientInformationRepositoryInterface::class)
+            )
         );
 
         $this->addShared(
             LogOut::class,
-            function () {
-                return new LogOut(
-                    $this->get(ClientInformationRepositoryInterface::class),
-                    $this->get(ResponseFactoryInterface::class)
-                );
-            }
+            fn (): \CultuurNet\UDB3\JwtProvider\Domain\Action\LogOut => new LogOut(
+                $this->get(ClientInformationRepositoryInterface::class),
+                $this->get(ResponseFactoryInterface::class)
+            )
         );
 
         $this->addShared(
             Refresh::class,
-            function () {
-                return new Refresh(
-                    $this->get(ResponseFactoryInterface::class),
-                    $this->get(RefreshServiceInterface::class)
-                );
-            }
+            fn (): \CultuurNet\UDB3\JwtProvider\Domain\Action\Refresh => new Refresh(
+                $this->get(ResponseFactoryInterface::class),
+                $this->get(RefreshServiceInterface::class)
+            )
         );
 
         $this->addShared(
             LogOutServiceInterface::class,
-            function () {
-                return new LogOutAuth0Adapter(
-                    $this->get(Auth0::class),
-                    new Authentication(
-                        [
-                            'domain' => $this->parameter('auth0.domain'),
-                            'clientId' => $this->parameter('auth0.client_id'),
-                            'clientSecret' => $this->parameter('auth0.client_secret'),
-                            'cookieSecret' => $this->parameter('auth0.cookie_secret'),
-                        ]
-                    ),
-                    $this->get(ResponseFactoryInterface::class),
-                    new UriFactory(),
-                    $this->parameter('auth0.log_out_uri'),
-                    $this->parameter('auth0.client_id')
-                );
-            }
-        );
-
-        $this->addShared(
-            ResponseFactoryInterface::class,
-            function () {
-                return new SlimResponseFactory();
-            }
-        );
-
-        $this->addShared(
-            LoginServiceInterface::class,
-            function () {
-                return new LoginAuth0Adapter(
-                    $this->get(Auth0::class)
-                );
-            }
-        );
-
-        $this->addShared(
-            RefreshServiceInterface::class,
-            function () {
-                return new RefreshAuth0Adapter(
-                    new Client(),
-                    $this->parameter('auth0.client_id'),
-                    $this->parameter('auth0.client_secret'),
-                    $this->parameter('auth0.domain')
-                );
-            }
-        );
-
-        $this->addShared(
-            Auth0::class,
-            function () {
-                return new Auth0(
+            fn (): \CultuurNet\UDB3\JwtProvider\Infrastructure\Service\LogOutAuth0Adapter => new LogOutAuth0Adapter(
+                $this->get(Auth0::class),
+                new Authentication(
                     [
                         'domain' => $this->parameter('auth0.domain'),
                         'clientId' => $this->parameter('auth0.client_id'),
                         'clientSecret' => $this->parameter('auth0.client_secret'),
-                        'redirectUri' => $this->parameter('auth0.redirect_uri'),
-                        'scope' => ['openid','email','profile','offline_access'],
-                        'persistIdToken' => true,
-                        'persistRefreshToken' => true,
-                        'tokenLeeway' => $this->parameter('auth0.id_token_leeway'),
                         'cookieSecret' => $this->parameter('auth0.cookie_secret'),
                     ]
-                );
-            }
+                ),
+                $this->get(ResponseFactoryInterface::class),
+                new UriFactory(),
+                $this->parameter('auth0.log_out_uri'),
+                $this->parameter('auth0.client_id')
+            )
+        );
+
+        $this->addShared(
+            ResponseFactoryInterface::class,
+            fn (): \CultuurNet\UDB3\JwtProvider\Infrastructure\Factory\SlimResponseFactory => new SlimResponseFactory()
+        );
+
+        $this->addShared(
+            LoginServiceInterface::class,
+            fn (): \CultuurNet\UDB3\JwtProvider\Infrastructure\Service\LoginAuth0Adapter => new LoginAuth0Adapter(
+                $this->get(Auth0::class)
+            )
+        );
+
+        $this->addShared(
+            RefreshServiceInterface::class,
+            fn (): \CultuurNet\UDB3\JwtProvider\Infrastructure\Service\RefreshAuth0Adapter => new RefreshAuth0Adapter(
+                new Client(),
+                $this->parameter('auth0.client_id'),
+                $this->parameter('auth0.client_secret'),
+                $this->parameter('auth0.domain')
+            )
+        );
+
+        $this->addShared(
+            Auth0::class,
+            fn (): \Auth0\SDK\Auth0 => new Auth0(
+                [
+                    'domain' => $this->parameter('auth0.domain'),
+                    'clientId' => $this->parameter('auth0.client_id'),
+                    'clientSecret' => $this->parameter('auth0.client_secret'),
+                    'redirectUri' => $this->parameter('auth0.redirect_uri'),
+                    'scope' => ['openid','email','profile','offline_access'],
+                    'persistIdToken' => true,
+                    'persistRefreshToken' => true,
+                    'tokenLeeway' => $this->parameter('auth0.id_token_leeway'),
+                    'cookieSecret' => $this->parameter('auth0.cookie_secret'),
+                ]
+            )
         );
 
         $this->addShared(
             IsAllowedRefreshToken::class,
-            function () {
-                return new IsAllowedRefreshToken(
-                    $this->get(ConsumerReadRepositoryInterface::class),
-                    (string)$this->parameter('auth0.allowed_refresh_permission')
-                );
-            }
+            fn (): \CultuurNet\UDB3\JwtProvider\Infrastructure\Service\IsAllowedRefreshToken => new IsAllowedRefreshToken(
+                $this->get(ConsumerReadRepositoryInterface::class),
+                (string)$this->parameter('auth0.allowed_refresh_permission')
+            )
         );
 
         $this->addShared(
             ClientInformationRepositoryInterface::class,
-            function () {
+            function (): \CultuurNet\UDB3\JwtProvider\Infrastructure\Repository\SessionClientInformation {
                 $session = $this->get(Session::class);
                 $segment = $session->getSegment(ClientInformationRepositoryInterface::class);
                 return new SessionClientInformation(
@@ -193,13 +171,11 @@ final class ActionServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             ExtractClientInformationFromRequest::class,
-            function () {
-                return new ExtractClientInformationFromRequest(
-                    new UriFactory(),
-                    $this->get(ApiKeyReaderInterface::class),
-                    $this->get(IsAllowedRefreshToken::class)
-                );
-            }
+            fn (): \CultuurNet\UDB3\JwtProvider\Infrastructure\Service\ExtractClientInformationFromRequest => new ExtractClientInformationFromRequest(
+                new UriFactory(),
+                $this->get(ApiKeyReaderInterface::class),
+                $this->get(IsAllowedRefreshToken::class)
+            )
         );
     }
 }

--- a/app/ApiGuardServiceProvider.php
+++ b/app/ApiGuardServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\JwtProvider;
 
+use CultureFeed_DefaultOAuthClient;
 use CultureFeed;
 use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\ApiKeyReaderInterface;
 use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\CompositeApiKeyReader;
@@ -30,7 +31,7 @@ final class ApiGuardServiceProvider extends BaseServiceProvider
     {
         $this->addShared(
             ApiKeyReaderInterface::class,
-            function (): \CultuurNet\UDB3\ApiGuard\ApiKey\Reader\CompositeApiKeyReader {
+            function (): CompositeApiKeyReader {
                 $queryReader = new QueryParameterApiKeyReader('apiKey');
                 $headerReader = new CustomHeaderApiKeyReader('X-Api-Key');
 
@@ -43,13 +44,13 @@ final class ApiGuardServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             ConsumerReadRepositoryInterface::class,
-            fn (): \CultuurNet\UDB3\JwtProvider\Domain\Service\CultureFeedConsumerReadRepository => new CultureFeedConsumerReadRepository($this->get(ICultureFeed::class))
+            fn (): CultureFeedConsumerReadRepository => new CultureFeedConsumerReadRepository($this->get(ICultureFeed::class))
         );
 
         $this->addShared(
             ICultureFeed::class,
-            function (): \CultureFeed {
-                $oauthClient = new \CultureFeed_DefaultOAuthClient(
+            function (): CultureFeed {
+                $oauthClient = new CultureFeed_DefaultOAuthClient(
                     $this->parameter('uitid.consumer.key'),
                     $this->parameter('uitid.consumer.secret')
                 );

--- a/app/ApiGuardServiceProvider.php
+++ b/app/ApiGuardServiceProvider.php
@@ -26,11 +26,11 @@ final class ApiGuardServiceProvider extends BaseServiceProvider
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): void
     {
         $this->addShared(
             ApiKeyReaderInterface::class,
-            function () {
+            function (): \CultuurNet\UDB3\ApiGuard\ApiKey\Reader\CompositeApiKeyReader {
                 $queryReader = new QueryParameterApiKeyReader('apiKey');
                 $headerReader = new CustomHeaderApiKeyReader('X-Api-Key');
 
@@ -43,14 +43,12 @@ final class ApiGuardServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             ConsumerReadRepositoryInterface::class,
-            function () {
-                return new CultureFeedConsumerReadRepository($this->get(ICultureFeed::class));
-            }
+            fn (): \CultuurNet\UDB3\JwtProvider\Domain\Service\CultureFeedConsumerReadRepository => new CultureFeedConsumerReadRepository($this->get(ICultureFeed::class))
         );
 
         $this->addShared(
             ICultureFeed::class,
-            function () {
+            function (): \CultureFeed {
                 $oauthClient = new \CultureFeed_DefaultOAuthClient(
                     $this->parameter('uitid.consumer.key'),
                     $this->parameter('uitid.consumer.secret')

--- a/app/Error/ApiExceptionHandler.php
+++ b/app/Error/ApiExceptionHandler.php
@@ -13,10 +13,7 @@ use Whoops\Handler\Handler;
 
 final class ApiExceptionHandler extends Handler
 {
-    /**
-     * @var EmitterInterface
-     */
-    private $emitter;
+    private \Laminas\HttpHandlerRunner\Emitter\EmitterInterface $emitter;
 
     public function __construct(EmitterInterface $emitter)
     {

--- a/app/Error/ApiExceptionHandler.php
+++ b/app/Error/ApiExceptionHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\JwtProvider\Error;
 
+use Throwable;
 use CultuurNet\UDB3\JwtProvider\Domain\Exception\JwtProviderExceptionInterface;
 use Fig\Http\Message\StatusCodeInterface;
 use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
@@ -13,7 +14,7 @@ use Whoops\Handler\Handler;
 
 final class ApiExceptionHandler extends Handler
 {
-    private \Laminas\HttpHandlerRunner\Emitter\EmitterInterface $emitter;
+    private EmitterInterface $emitter;
 
     public function __construct(EmitterInterface $emitter)
     {
@@ -31,7 +32,7 @@ final class ApiExceptionHandler extends Handler
         return Handler::QUIT;
     }
 
-    private function generateResponse(\Throwable $exception): ResponseInterface
+    private function generateResponse(Throwable $exception): ResponseInterface
     {
         if ($exception instanceof JwtProviderExceptionInterface) {
             $response = new Response(StatusCodeInterface::STATUS_BAD_REQUEST);

--- a/app/Error/ErrorLoggerHandler.php
+++ b/app/Error/ErrorLoggerHandler.php
@@ -22,10 +22,7 @@ final class ErrorLoggerHandler extends Handler
         JwtProviderExceptionInterface::class,
     ];
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private \Psr\Log\LoggerInterface $logger;
 
     public function __construct(LoggerInterface $logger)
     {

--- a/app/Error/ErrorLoggerHandler.php
+++ b/app/Error/ErrorLoggerHandler.php
@@ -22,7 +22,7 @@ final class ErrorLoggerHandler extends Handler
         JwtProviderExceptionInterface::class,
     ];
 
-    private \Psr\Log\LoggerInterface $logger;
+    private LoggerInterface $logger;
 
     public function __construct(LoggerInterface $logger)
     {

--- a/app/Error/LoggerFactory.php
+++ b/app/Error/LoggerFactory.php
@@ -16,12 +16,12 @@ final class LoggerFactory
     /**
      * @var Logger[]
      */
-    private static $loggers;
+    private static ?array $loggers = null;
 
     /**
      * @var StreamHandler[]
      */
-    private static $streamHandlers = [];
+    private static array $streamHandlers = [];
 
     /**
      * @param HandlerInterface[] $extraHandlers

--- a/app/Error/LoggerName.php
+++ b/app/Error/LoggerName.php
@@ -6,15 +6,9 @@ namespace CultuurNet\UDB3\JwtProvider\Error;
 
 final class LoggerName
 {
-    /**
-     * @var string
-     */
-    private $fileNameWithoutSuffix;
+    private string $fileNameWithoutSuffix;
 
-    /**
-     * @var string
-     */
-    private $loggerName;
+    private string $loggerName;
 
     public function __construct(string $fileNameWithoutSuffix, ?string $customLoggerName = null)
     {

--- a/app/Error/SentryHandlerScopeDecorator.php
+++ b/app/Error/SentryHandlerScopeDecorator.php
@@ -15,20 +15,11 @@ use function Sentry\withScope;
  */
 final class SentryHandlerScopeDecorator implements HandlerInterface
 {
-    /**
-     * @var HandlerInterface
-     */
-    private $decoratedHandler;
+    private \Monolog\Handler\HandlerInterface $decoratedHandler;
 
-    /**
-     * @var ApiKey
-     */
-    private $apiKey;
+    private \CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey $apiKey;
 
-    /**
-     * @var bool
-     */
-    private $console;
+    private bool $console;
 
     private function __construct(HandlerInterface $decoratedHandler, ApiKey $apiKey, bool $console)
     {
@@ -39,7 +30,7 @@ final class SentryHandlerScopeDecorator implements HandlerInterface
 
     public static function forWeb(HandlerInterface $decoratedHandler, ?ApiKey $apiKey): self
     {
-        $apiKey = $apiKey ?? new ApiKey('null');
+        $apiKey ??= new ApiKey('null');
         return new self($decoratedHandler, $apiKey, false);
     }
 

--- a/app/Error/SentryHandlerScopeDecorator.php
+++ b/app/Error/SentryHandlerScopeDecorator.php
@@ -15,9 +15,9 @@ use function Sentry\withScope;
  */
 final class SentryHandlerScopeDecorator implements HandlerInterface
 {
-    private \Monolog\Handler\HandlerInterface $decoratedHandler;
+    private HandlerInterface $decoratedHandler;
 
-    private \CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey $apiKey;
+    private ApiKey $apiKey;
 
     private bool $console;
 

--- a/app/Error/SentryHubServiceProvider.php
+++ b/app/Error/SentryHubServiceProvider.php
@@ -22,7 +22,7 @@ final class SentryHubServiceProvider extends BaseServiceProvider
     {
         $this->add(
             HubInterface::class,
-            function () {
+            function (): \Sentry\State\HubInterface {
                 init([
                     'dsn' => $this->parameter('sentry.dsn'),
                     'environment' => $this->parameter('sentry.environment'),

--- a/app/Error/SentryHubServiceProvider.php
+++ b/app/Error/SentryHubServiceProvider.php
@@ -22,7 +22,7 @@ final class SentryHubServiceProvider extends BaseServiceProvider
     {
         $this->add(
             HubInterface::class,
-            function (): \Sentry\State\HubInterface {
+            function (): HubInterface {
                 init([
                     'dsn' => $this->parameter('sentry.dsn'),
                     'environment' => $this->parameter('sentry.environment'),

--- a/app/Error/SentryWebServiceProvider.php
+++ b/app/Error/SentryWebServiceProvider.php
@@ -23,7 +23,7 @@ final class SentryWebServiceProvider extends BaseServiceProvider
     {
         $this->addShared(
             SentryHandlerScopeDecorator::class,
-            fn (): \CultuurNet\UDB3\JwtProvider\Error\SentryHandlerScopeDecorator => SentryHandlerScopeDecorator::forWeb(
+            fn (): SentryHandlerScopeDecorator => SentryHandlerScopeDecorator::forWeb(
                 new SentryHandler($this->get(HubInterface::class), Logger::ERROR),
                 $this->get(ApiKey::class)
             )

--- a/app/Error/SentryWebServiceProvider.php
+++ b/app/Error/SentryWebServiceProvider.php
@@ -23,12 +23,10 @@ final class SentryWebServiceProvider extends BaseServiceProvider
     {
         $this->addShared(
             SentryHandlerScopeDecorator::class,
-            function () {
-                return SentryHandlerScopeDecorator::forWeb(
-                    new SentryHandler($this->get(HubInterface::class), Logger::ERROR),
-                    $this->get(ApiKey::class)
-                );
-            }
+            fn (): \CultuurNet\UDB3\JwtProvider\Error\SentryHandlerScopeDecorator => SentryHandlerScopeDecorator::forWeb(
+                new SentryHandler($this->get(HubInterface::class), Logger::ERROR),
+                $this->get(ApiKey::class)
+            )
         );
     }
 }

--- a/app/MiddlewareServiceProvider.php
+++ b/app/MiddlewareServiceProvider.php
@@ -20,16 +20,14 @@ final class MiddlewareServiceProvider extends BaseServiceProvider
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): void
     {
         $this->addShared(
             AllowedRefresh::class,
-            function () {
-                return new AllowedRefresh(
-                    $this->get(IsAllowedRefreshToken::class),
-                    $this->get(ApiKeyReaderInterface::class)
-                );
-            }
+            fn (): \CultuurNet\UDB3\JwtProvider\Domain\Middleware\AllowedRefresh => new AllowedRefresh(
+                $this->get(IsAllowedRefreshToken::class),
+                $this->get(ApiKeyReaderInterface::class)
+            )
         );
     }
 }

--- a/app/MiddlewareServiceProvider.php
+++ b/app/MiddlewareServiceProvider.php
@@ -24,7 +24,7 @@ final class MiddlewareServiceProvider extends BaseServiceProvider
     {
         $this->addShared(
             AllowedRefresh::class,
-            fn (): \CultuurNet\UDB3\JwtProvider\Domain\Middleware\AllowedRefresh => new AllowedRefresh(
+            fn (): AllowedRefresh => new AllowedRefresh(
                 $this->get(IsAllowedRefreshToken::class),
                 $this->get(ApiKeyReaderInterface::class)
             )

--- a/app/RoutingServiceProvider.php
+++ b/app/RoutingServiceProvider.php
@@ -26,7 +26,7 @@ final class RoutingServiceProvider extends BaseServiceProvider
     {
         $this->add(
             Router::class,
-            function (): \League\Route\Router {
+            function (): Router {
                 $router = new Router();
                 $strategy = (new ApplicationStrategy())->setContainer($this->getContainer());
                 $router->setStrategy($strategy);

--- a/app/RoutingServiceProvider.php
+++ b/app/RoutingServiceProvider.php
@@ -26,7 +26,7 @@ final class RoutingServiceProvider extends BaseServiceProvider
     {
         $this->add(
             Router::class,
-            function () {
+            function (): \League\Route\Router {
                 $router = new Router();
                 $strategy = (new ApplicationStrategy())->setContainer($this->getContainer());
                 $router->setStrategy($strategy);

--- a/app/SessionServiceProvider.php
+++ b/app/SessionServiceProvider.php
@@ -19,7 +19,7 @@ final class SessionServiceProvider extends BaseServiceProvider
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): void
     {
         $this->addShared(
             Session::class,

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
     "publiq/php-cs-fixer-config": "^1.3",
     "jangregor/phpstan-prophecy": "^1.0",
     "phpunit/phpunit": "^9.6",
-    "phpspec/prophecy-phpunit": "^2.2"
+    "phpspec/prophecy-phpunit": "^2.2",
+    "rector/rector": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5dbfd5f1dbc948e331161bc9e390bdb",
+    "content-hash": "64a2f862a0eed10cb4f9557b697c022e",
     "packages": [
         {
             "name": "aura/session",
@@ -5071,6 +5071,62 @@
                 "source": "https://github.com/cultuurnet/php-cs-fixer-config/tree/v1.3.1"
             },
             "time": "2021-02-26T12:16:58+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "c59507a9090b465d65e1aceed91e5b81986e375b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/c59507a9090b465d65e1aceed91e5b81986e375b",
+                "reference": "c59507a9090b465d65e1aceed91e5b81986e375b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.10.57"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/1.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T15:04:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/rector.php
+++ b/rector.php
@@ -13,6 +13,7 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
         __DIR__ . '/web',
     ])
+    ->withImportNames()
     ->withPhpSets(php74: true)
     ->withSets([SetList::TYPE_DECLARATION]) //rule to force typed declarations
     ->withRules([

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\SetList;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/app',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+        __DIR__ . '/web',
+    ])
+    ->withPhpSets(php74: true)
+    ->withSets([SetList::TYPE_DECLARATION]) //rule to force typed declarations
+    ->withRules([
+        AddVoidReturnTypeWhereNoReturnRector::class,
+    ]);

--- a/src/Domain/Action/LogOut.php
+++ b/src/Domain/Action/LogOut.php
@@ -11,15 +11,9 @@ use Psr\Http\Message\ResponseInterface;
 
 final class LogOut
 {
-    /**
-     * @var ClientInformationRepositoryInterface
-     */
-    private $clientInformationRepository;
+    private \CultuurNet\UDB3\JwtProvider\Domain\Repository\ClientInformationRepositoryInterface $clientInformationRepository;
 
-    /**
-     * @var ResponseFactoryInterface
-     */
-    private $responseFactory;
+    private \CultuurNet\UDB3\JwtProvider\Domain\Factory\ResponseFactoryInterface $responseFactory;
 
     public function __construct(
         ClientInformationRepositoryInterface $clientInformationRepository,

--- a/src/Domain/Action/LogOut.php
+++ b/src/Domain/Action/LogOut.php
@@ -11,9 +11,9 @@ use Psr\Http\Message\ResponseInterface;
 
 final class LogOut
 {
-    private \CultuurNet\UDB3\JwtProvider\Domain\Repository\ClientInformationRepositoryInterface $clientInformationRepository;
+    private ClientInformationRepositoryInterface $clientInformationRepository;
 
-    private \CultuurNet\UDB3\JwtProvider\Domain\Factory\ResponseFactoryInterface $responseFactory;
+    private ResponseFactoryInterface $responseFactory;
 
     public function __construct(
         ClientInformationRepositoryInterface $clientInformationRepository,

--- a/src/Domain/Action/Refresh.php
+++ b/src/Domain/Action/Refresh.php
@@ -13,15 +13,9 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final class Refresh
 {
-    /**
-     * @var ResponseFactoryInterface
-     */
-    private $responseFactory;
+    private \CultuurNet\UDB3\JwtProvider\Domain\Factory\ResponseFactoryInterface $responseFactory;
 
-    /**
-     * @var RefreshServiceInterface
-     */
-    private $refreshService;
+    private \CultuurNet\UDB3\JwtProvider\Domain\Service\RefreshServiceInterface $refreshService;
 
     public function __construct(ResponseFactoryInterface $responseFactory, RefreshServiceInterface $refreshService)
     {

--- a/src/Domain/Action/Refresh.php
+++ b/src/Domain/Action/Refresh.php
@@ -13,9 +13,9 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final class Refresh
 {
-    private \CultuurNet\UDB3\JwtProvider\Domain\Factory\ResponseFactoryInterface $responseFactory;
+    private ResponseFactoryInterface $responseFactory;
 
-    private \CultuurNet\UDB3\JwtProvider\Domain\Service\RefreshServiceInterface $refreshService;
+    private RefreshServiceInterface $refreshService;
 
     public function __construct(ResponseFactoryInterface $responseFactory, RefreshServiceInterface $refreshService)
     {

--- a/src/Domain/Action/RequestLogout.php
+++ b/src/Domain/Action/RequestLogout.php
@@ -13,20 +13,11 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final class RequestLogout
 {
-    /**
-     * @var LogOutServiceInterface
-     */
-    private $logOutService;
+    private \CultuurNet\UDB3\JwtProvider\Domain\Service\LogOutServiceInterface $logOutService;
 
-    /**
-     * @var ClientInformationRepositoryInterface
-     */
-    private $clientInformationRepository;
+    private \CultuurNet\UDB3\JwtProvider\Domain\Repository\ClientInformationRepositoryInterface $clientInformationRepository;
 
-    /**
-     * @var ExtractClientInformationFromRequestInterface
-     */
-    private $extractClientInformationFromRequest;
+    private \CultuurNet\UDB3\JwtProvider\Domain\Service\ExtractClientInformationFromRequestInterface $extractClientInformationFromRequest;
 
     public function __construct(
         ExtractClientInformationFromRequestInterface $extractClientInformationFromRequest,

--- a/src/Domain/Action/RequestLogout.php
+++ b/src/Domain/Action/RequestLogout.php
@@ -13,11 +13,11 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final class RequestLogout
 {
-    private \CultuurNet\UDB3\JwtProvider\Domain\Service\LogOutServiceInterface $logOutService;
+    private LogOutServiceInterface $logOutService;
 
-    private \CultuurNet\UDB3\JwtProvider\Domain\Repository\ClientInformationRepositoryInterface $clientInformationRepository;
+    private ClientInformationRepositoryInterface $clientInformationRepository;
 
-    private \CultuurNet\UDB3\JwtProvider\Domain\Service\ExtractClientInformationFromRequestInterface $extractClientInformationFromRequest;
+    private ExtractClientInformationFromRequestInterface $extractClientInformationFromRequest;
 
     public function __construct(
         ExtractClientInformationFromRequestInterface $extractClientInformationFromRequest,

--- a/src/Domain/Action/RequestToken.php
+++ b/src/Domain/Action/RequestToken.php
@@ -14,25 +14,13 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final class RequestToken
 {
-    /**
-     * @var ExtractClientInformationFromRequestInterface
-     */
-    private $extractClientInformationFromRequest;
+    private \CultuurNet\UDB3\JwtProvider\Domain\Service\ExtractClientInformationFromRequestInterface $extractClientInformationFromRequest;
 
-    /**
-     * @var LoginServiceInterface
-     */
-    private $externalAuthService;
+    private \CultuurNet\UDB3\JwtProvider\Domain\Service\LoginServiceInterface $externalAuthService;
 
-    /**
-     * @var ClientInformationRepositoryInterface
-     */
-    private $clientInformationRepository;
+    private \CultuurNet\UDB3\JwtProvider\Domain\Repository\ClientInformationRepositoryInterface $clientInformationRepository;
 
-    /**
-     * @var ExtractLocaleFromRequest
-     */
-    private $extractLocaleFromRequest;
+    private \CultuurNet\UDB3\JwtProvider\Infrastructure\Service\ExtractLocaleFromRequest $extractLocaleFromRequest;
 
     public function __construct(
         ExtractClientInformationFromRequestInterface $extractClientInformationFromRequest,

--- a/src/Domain/Action/RequestToken.php
+++ b/src/Domain/Action/RequestToken.php
@@ -14,13 +14,13 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final class RequestToken
 {
-    private \CultuurNet\UDB3\JwtProvider\Domain\Service\ExtractClientInformationFromRequestInterface $extractClientInformationFromRequest;
+    private ExtractClientInformationFromRequestInterface $extractClientInformationFromRequest;
 
-    private \CultuurNet\UDB3\JwtProvider\Domain\Service\LoginServiceInterface $externalAuthService;
+    private LoginServiceInterface $externalAuthService;
 
-    private \CultuurNet\UDB3\JwtProvider\Domain\Repository\ClientInformationRepositoryInterface $clientInformationRepository;
+    private ClientInformationRepositoryInterface $clientInformationRepository;
 
-    private \CultuurNet\UDB3\JwtProvider\Infrastructure\Service\ExtractLocaleFromRequest $extractLocaleFromRequest;
+    private ExtractLocaleFromRequest $extractLocaleFromRequest;
 
     public function __construct(
         ExtractClientInformationFromRequestInterface $extractClientInformationFromRequest,

--- a/src/Domain/Exception/BadRequestException.php
+++ b/src/Domain/Exception/BadRequestException.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\JwtProvider\Domain\Exception;
 
+use Exception;
 use Fig\Http\Message\StatusCodeInterface;
 
-final class BadRequestException extends \Exception implements JwtProviderExceptionInterface
+final class BadRequestException extends Exception implements JwtProviderExceptionInterface
 {
     public static function missingRefreshToken(): BadRequestException
     {

--- a/src/Domain/Exception/ClientInformationNotPresentException.php
+++ b/src/Domain/Exception/ClientInformationNotPresentException.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\JwtProvider\Domain\Exception;
 
+use Exception;
 use Fig\Http\Message\StatusCodeInterface;
 
-final class ClientInformationNotPresentException extends \Exception implements JwtProviderExceptionInterface
+final class ClientInformationNotPresentException extends Exception implements JwtProviderExceptionInterface
 {
     public function getHttpCode(): int
     {

--- a/src/Domain/Exception/JwtProviderExceptionInterface.php
+++ b/src/Domain/Exception/JwtProviderExceptionInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\JwtProvider\Domain\Exception;
 
-interface JwtProviderExceptionInterface extends \Throwable
+use Throwable;
+
+interface JwtProviderExceptionInterface extends Throwable
 {
     public function getHttpCode(): int;
 }

--- a/src/Domain/Exception/RefreshTokenNotAllowedException.php
+++ b/src/Domain/Exception/RefreshTokenNotAllowedException.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\JwtProvider\Domain\Exception;
 
+use Exception;
 use Fig\Http\Message\StatusCodeInterface;
 
-final class RefreshTokenNotAllowedException extends \Exception implements JwtProviderExceptionInterface
+final class RefreshTokenNotAllowedException extends Exception implements JwtProviderExceptionInterface
 {
     public function getHttpCode(): int
     {

--- a/src/Domain/Exception/UnSuccessfulRefreshException.php
+++ b/src/Domain/Exception/UnSuccessfulRefreshException.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\JwtProvider\Domain\Exception;
 
+use Exception;
 use Fig\Http\Message\StatusCodeInterface;
 
-final class UnSuccessfulRefreshException extends \Exception implements JwtProviderExceptionInterface
+final class UnSuccessfulRefreshException extends Exception implements JwtProviderExceptionInterface
 {
     public function getHttpCode(): int
     {

--- a/src/Domain/Middleware/AllowedRefresh.php
+++ b/src/Domain/Middleware/AllowedRefresh.php
@@ -14,9 +14,9 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 final class AllowedRefresh implements MiddlewareInterface
 {
-    private \CultuurNet\UDB3\JwtProvider\Domain\Service\IsAllowedRefreshTokenInterface $isAllowedRefreshToken;
+    private IsAllowedRefreshTokenInterface $isAllowedRefreshToken;
 
-    private \CultuurNet\UDB3\ApiGuard\ApiKey\Reader\ApiKeyReaderInterface $apiKeyReader;
+    private ApiKeyReaderInterface $apiKeyReader;
 
     public function __construct(
         IsAllowedRefreshTokenInterface $isAllowedRefreshToken,

--- a/src/Domain/Middleware/AllowedRefresh.php
+++ b/src/Domain/Middleware/AllowedRefresh.php
@@ -14,15 +14,9 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 final class AllowedRefresh implements MiddlewareInterface
 {
-    /**
-     * @var IsAllowedRefreshTokenInterface
-     */
-    private $isAllowedRefreshToken;
+    private \CultuurNet\UDB3\JwtProvider\Domain\Service\IsAllowedRefreshTokenInterface $isAllowedRefreshToken;
 
-    /**
-     * @var ApiKeyReaderInterface
-     */
-    private $apiKeyReader;
+    private \CultuurNet\UDB3\ApiGuard\ApiKey\Reader\ApiKeyReaderInterface $apiKeyReader;
 
     public function __construct(
         IsAllowedRefreshTokenInterface $isAllowedRefreshToken,

--- a/src/Domain/Service/CultureFeedConsumerReadRepository.php
+++ b/src/Domain/Service/CultureFeedConsumerReadRepository.php
@@ -13,10 +13,7 @@ use ICultureFeed;
 
 final class CultureFeedConsumerReadRepository implements ConsumerReadRepositoryInterface
 {
-    /**
-     * @var ICultureFeed
-     */
-    private $cultureFeed;
+    private \ICultureFeed $cultureFeed;
 
     public function __construct(ICultureFeed $cultureFeed)
     {

--- a/src/Domain/Service/CultureFeedConsumerReadRepository.php
+++ b/src/Domain/Service/CultureFeedConsumerReadRepository.php
@@ -13,7 +13,7 @@ use ICultureFeed;
 
 final class CultureFeedConsumerReadRepository implements ConsumerReadRepositoryInterface
 {
-    private \ICultureFeed $cultureFeed;
+    private ICultureFeed $cultureFeed;
 
     public function __construct(ICultureFeed $cultureFeed)
     {

--- a/src/Domain/Value/ClientInformation.php
+++ b/src/Domain/Value/ClientInformation.php
@@ -9,9 +9,9 @@ use Psr\Http\Message\UriInterface;
 
 final class ClientInformation
 {
-    private \Psr\Http\Message\UriInterface $uri;
+    private UriInterface $uri;
 
-    private ?\CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey $apiKey;
+    private ?ApiKey $apiKey;
 
     private bool $isAllowedRefresh;
 

--- a/src/Domain/Value/ClientInformation.php
+++ b/src/Domain/Value/ClientInformation.php
@@ -9,20 +9,11 @@ use Psr\Http\Message\UriInterface;
 
 final class ClientInformation
 {
-    /**
-     * @var UriInterface
-     */
-    private $uri;
+    private \Psr\Http\Message\UriInterface $uri;
 
-    /**
-     * @var ApiKey|null
-     */
-    private $apiKey;
+    private ?\CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey $apiKey;
 
-    /**
-     * @var bool
-     */
-    private $isAllowedRefresh;
+    private bool $isAllowedRefresh;
 
     public function __construct(UriInterface $uri, ApiKey $apiKey = null, bool $isAllowedRefresh = false)
     {

--- a/src/Infrastructure/Repository/SessionClientInformation.php
+++ b/src/Infrastructure/Repository/SessionClientInformation.php
@@ -12,10 +12,7 @@ final class SessionClientInformation implements ClientInformationRepositoryInter
 {
     private const KEY = 'ClientInformation';
 
-    /**
-     * @var Segment
-     */
-    private $segment;
+    private \Aura\Session\Segment $segment;
 
     public function __construct(Segment $segment)
     {

--- a/src/Infrastructure/Repository/SessionClientInformation.php
+++ b/src/Infrastructure/Repository/SessionClientInformation.php
@@ -12,7 +12,7 @@ final class SessionClientInformation implements ClientInformationRepositoryInter
 {
     private const KEY = 'ClientInformation';
 
-    private \Aura\Session\Segment $segment;
+    private Segment $segment;
 
     public function __construct(Segment $segment)
     {

--- a/src/Infrastructure/Service/ExtractClientInformationFromRequest.php
+++ b/src/Infrastructure/Service/ExtractClientInformationFromRequest.php
@@ -16,11 +16,11 @@ final class ExtractClientInformationFromRequest implements ExtractClientInformat
 {
     public const DESTINATION = 'destination';
 
-    private \Psr\Http\Message\UriFactoryInterface $uriFactory;
+    private UriFactoryInterface $uriFactory;
 
-    private \CultuurNet\UDB3\ApiGuard\ApiKey\Reader\ApiKeyReaderInterface $apiKeyReader;
+    private ApiKeyReaderInterface $apiKeyReader;
 
-    private \CultuurNet\UDB3\JwtProvider\Domain\Service\IsAllowedRefreshTokenInterface $isAllowedRefreshToken;
+    private IsAllowedRefreshTokenInterface $isAllowedRefreshToken;
 
     public function __construct(
         UriFactoryInterface $uriFactory,

--- a/src/Infrastructure/Service/ExtractClientInformationFromRequest.php
+++ b/src/Infrastructure/Service/ExtractClientInformationFromRequest.php
@@ -16,20 +16,11 @@ final class ExtractClientInformationFromRequest implements ExtractClientInformat
 {
     public const DESTINATION = 'destination';
 
-    /**
-     * @var UriFactoryInterface
-     */
-    private $uriFactory;
+    private \Psr\Http\Message\UriFactoryInterface $uriFactory;
 
-    /**
-     * @var ApiKeyReaderInterface
-     */
-    private $apiKeyReader;
+    private \CultuurNet\UDB3\ApiGuard\ApiKey\Reader\ApiKeyReaderInterface $apiKeyReader;
 
-    /**
-     * @var IsAllowedRefreshTokenInterface
-     */
-    private $isAllowedRefreshToken;
+    private \CultuurNet\UDB3\JwtProvider\Domain\Service\IsAllowedRefreshTokenInterface $isAllowedRefreshToken;
 
     public function __construct(
         UriFactoryInterface $uriFactory,

--- a/src/Infrastructure/Service/ExtractLocaleFromRequest.php
+++ b/src/Infrastructure/Service/ExtractLocaleFromRequest.php
@@ -23,6 +23,6 @@ final class ExtractLocaleFromRequest
     private function extractParameter(ServerRequestInterface $serverRequest): ?string
     {
         $queryParams = $serverRequest->getQueryParams();
-        return isset($queryParams['lang']) ? $queryParams['lang'] : null;
+        return $queryParams['lang'] ?? null;
     }
 }

--- a/src/Infrastructure/Service/IsAllowedRefreshToken.php
+++ b/src/Infrastructure/Service/IsAllowedRefreshToken.php
@@ -13,7 +13,7 @@ final class IsAllowedRefreshToken implements IsAllowedRefreshTokenInterface
 {
     private string $refreshGroupId;
 
-    private \CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepositoryInterface $consumerReadRepository;
+    private ConsumerReadRepositoryInterface $consumerReadRepository;
 
     public function __construct(
         ConsumerReadRepositoryInterface $consumerReadRepository,

--- a/src/Infrastructure/Service/IsAllowedRefreshToken.php
+++ b/src/Infrastructure/Service/IsAllowedRefreshToken.php
@@ -11,15 +11,9 @@ use CultuurNet\UDB3\JwtProvider\Domain\Service\IsAllowedRefreshTokenInterface;
 
 final class IsAllowedRefreshToken implements IsAllowedRefreshTokenInterface
 {
-    /**
-     * @var string
-     */
-    private $refreshGroupId;
+    private string $refreshGroupId;
 
-    /**
-     * @var ConsumerReadRepositoryInterface
-     */
-    private $consumerReadRepository;
+    private \CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepositoryInterface $consumerReadRepository;
 
     public function __construct(
         ConsumerReadRepositoryInterface $consumerReadRepository,

--- a/src/Infrastructure/Service/LogOutAuth0Adapter.php
+++ b/src/Infrastructure/Service/LogOutAuth0Adapter.php
@@ -14,35 +14,17 @@ use Psr\Http\Message\UriInterface;
 
 final class LogOutAuth0Adapter implements LogOutServiceInterface
 {
-    /**
-     * @var ResponseFactoryInterface
-     */
-    private $responseFactory;
+    private \CultuurNet\UDB3\JwtProvider\Domain\Factory\ResponseFactoryInterface $responseFactory;
 
-    /**
-     * @var UriFactoryInterface
-     */
-    private $uriFactory;
+    private \Psr\Http\Message\UriFactoryInterface $uriFactory;
 
-    /**
-     * @var string
-     */
-    private $logOutUri;
+    private string $logOutUri;
 
-    /**
-     * @var AuthenticationInterface
-     */
-    private $authentication;
+    private \Auth0\SDK\Contract\API\AuthenticationInterface $authentication;
 
-    /**
-     * @var Auth0Interface
-     */
-    private $auth0;
+    private \Auth0\SDK\Contract\Auth0Interface $auth0;
 
-    /**
-     * @var string
-     */
-    private $clientId;
+    private string $clientId;
 
 
     public function __construct(

--- a/src/Infrastructure/Service/LogOutAuth0Adapter.php
+++ b/src/Infrastructure/Service/LogOutAuth0Adapter.php
@@ -14,15 +14,15 @@ use Psr\Http\Message\UriInterface;
 
 final class LogOutAuth0Adapter implements LogOutServiceInterface
 {
-    private \CultuurNet\UDB3\JwtProvider\Domain\Factory\ResponseFactoryInterface $responseFactory;
+    private ResponseFactoryInterface $responseFactory;
 
-    private \Psr\Http\Message\UriFactoryInterface $uriFactory;
+    private UriFactoryInterface $uriFactory;
 
     private string $logOutUri;
 
-    private \Auth0\SDK\Contract\API\AuthenticationInterface $authentication;
+    private AuthenticationInterface $authentication;
 
-    private \Auth0\SDK\Contract\Auth0Interface $auth0;
+    private Auth0Interface $auth0;
 
     private string $clientId;
 

--- a/src/Infrastructure/Service/LoginAuth0Adapter.php
+++ b/src/Infrastructure/Service/LoginAuth0Adapter.php
@@ -15,10 +15,7 @@ use Slim\Psr7\Response;
 
 final class LoginAuth0Adapter implements LoginServiceInterface
 {
-    /**
-     * @var Auth0Interface
-     */
-    private $auth0;
+    private \Auth0\SDK\Contract\Auth0Interface $auth0;
 
     public function __construct(Auth0Interface $auth0)
     {

--- a/src/Infrastructure/Service/LoginAuth0Adapter.php
+++ b/src/Infrastructure/Service/LoginAuth0Adapter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\JwtProvider\Infrastructure\Service;
 
+use Exception;
 use Auth0\SDK\Contract\Auth0Interface;
 use Auth0\SDK\Exception\NetworkException;
 use Auth0\SDK\Exception\StateException;
@@ -15,7 +16,7 @@ use Slim\Psr7\Response;
 
 final class LoginAuth0Adapter implements LoginServiceInterface
 {
-    private \Auth0\SDK\Contract\Auth0Interface $auth0;
+    private Auth0Interface $auth0;
 
     public function __construct(Auth0Interface $auth0)
     {
@@ -50,7 +51,7 @@ final class LoginAuth0Adapter implements LoginServiceInterface
     {
         try {
             return $this->auth0->getRefreshToken();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             throw new UnSuccessfulAuthException();
         }
     }

--- a/src/Infrastructure/Service/RefreshAuth0Adapter.php
+++ b/src/Infrastructure/Service/RefreshAuth0Adapter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\JwtProvider\Infrastructure\Service;
 
+use JsonException;
 use CultuurNet\UDB3\JwtProvider\Domain\Exception\UnSuccessfulRefreshException;
 use CultuurNet\UDB3\JwtProvider\Domain\Service\RefreshServiceInterface;
 use GuzzleHttp\Client;
@@ -11,7 +12,7 @@ use GuzzleHttp\Exception\GuzzleException;
 
 final class RefreshAuth0Adapter implements RefreshServiceInterface
 {
-    private \GuzzleHttp\Client $httpClient;
+    private Client $httpClient;
 
     private string $clientId;
 
@@ -42,7 +43,7 @@ final class RefreshAuth0Adapter implements RefreshServiceInterface
             );
             $res = json_decode((string)$response->getBody(), true, 512, JSON_THROW_ON_ERROR);
             return $res['id_token'];
-        } catch (\JsonException|GuzzleException $exception) {
+        } catch (JsonException|GuzzleException $exception) {
             throw new UnSuccessfulRefreshException($exception->getMessage());
         }
     }

--- a/src/Infrastructure/Service/RefreshAuth0Adapter.php
+++ b/src/Infrastructure/Service/RefreshAuth0Adapter.php
@@ -11,17 +11,13 @@ use GuzzleHttp\Exception\GuzzleException;
 
 final class RefreshAuth0Adapter implements RefreshServiceInterface
 {
-    /** @var Client */
-    private $httpClient;
+    private \GuzzleHttp\Client $httpClient;
 
-    /** @var string */
-    private $clientId;
+    private string $clientId;
 
-    /** @var string */
-    private $clientSecret;
+    private string $clientSecret;
 
-    /** @var string */
-    private $domain;
+    private string $domain;
 
     public function __construct(Client $client, string $clientId, string $clientSecret, string $domain)
     {

--- a/tests/MockConsumer.php
+++ b/tests/MockConsumer.php
@@ -9,25 +9,16 @@ use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerInterface;
 
 final class MockConsumer implements ConsumerInterface
 {
-    /**
-     * @var ApiKey
-     */
-    private $apiKey;
+    private \CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey $apiKey;
 
     /**
      * @var string[]
      */
-    private $permissionGroupIds = [];
+    private array $permissionGroupIds = [];
 
-    /**
-     * @var string|null
-     */
-    private $defaultQuery;
+    private ?string $defaultQuery = null;
 
-    /**
-     * @var string|null
-     */
-    private $name;
+    private ?string $name = null;
 
     public function __construct(ApiKey $apiKey)
     {

--- a/tests/MockConsumer.php
+++ b/tests/MockConsumer.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerInterface;
 
 final class MockConsumer implements ConsumerInterface
 {
-    private \CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey $apiKey;
+    private ApiKey $apiKey;
 
     /**
      * @var string[]


### PR DESCRIPTION
### Added
I added the Rector library as dev dependency.
I used this to help me upgrade all code to PHP 7.4 standards.

Main changes are:
- Use shorter anonymus function syntac
- Use typed properties everywhere
-  Return void where no return type is defined
- use shorter null coalescing operator (??=)

---
Ticket: https://jira.publiq.be/browse/III-6082