### PR TITLE
III-6207 keycloak jwt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ config.yml
 /log
 /.php_cs.cache
 .phpunit.result.cache
+jwt-example*.php
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ config.yml
 /log
 /.php_cs.cache
 .phpunit.result.cache
-jwt-example*.php
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down build install ci bash init
+.PHONY: up down build install ci bash init config
 
 up:
 	docker-compose up -d
@@ -20,5 +20,8 @@ cs-fix:
 
 bash:
 	docker exec -it jwt-provider bash
+
+config:
+	sh ./docker/config.sh
 
 init: install

--- a/app/ActionServiceProvider.php
+++ b/app/ActionServiceProvider.php
@@ -98,16 +98,16 @@ final class ActionServiceProvider extends BaseServiceProvider
                 $this->get(Auth0::class),
                 new Authentication(
                     [
-                        'domain' => $this->parameter('auth0.domain'),
-                        'clientId' => $this->parameter('auth0.client_id'),
-                        'clientSecret' => $this->parameter('auth0.client_secret'),
-                        'cookieSecret' => $this->parameter('auth0.cookie_secret'),
+                        'domain' => $this->parameter($this->getIdentityProvider() . '.domain'),
+                        'clientId' => $this->parameter($this->getIdentityProvider() . '.client_id'),
+                        'clientSecret' => $this->parameter($this->getIdentityProvider() . '.client_secret'),
+                        'cookieSecret' => $this->parameter($this->getIdentityProvider() . '.cookie_secret'),
                     ]
                 ),
                 $this->get(ResponseFactoryInterface::class),
                 new UriFactory(),
-                $this->parameter('auth0.log_out_uri'),
-                $this->parameter('auth0.client_id')
+                $this->parameter($this->getIdentityProvider() . '.log_out_uri'),
+                $this->parameter($this->getIdentityProvider() . '.client_id')
             )
         );
 
@@ -127,9 +127,10 @@ final class ActionServiceProvider extends BaseServiceProvider
             RefreshServiceInterface::class,
             fn (): RefreshAuth0Adapter => new RefreshAuth0Adapter(
                 new Client(),
-                $this->parameter('auth0.client_id'),
-                $this->parameter('auth0.client_secret'),
-                $this->parameter('auth0.domain')
+                $this->parameter($this->getIdentityProvider() . '.client_id'),
+                $this->parameter($this->getIdentityProvider() . '.client_secret'),
+                $this->parameter($this->getIdentityProvider() . '.domain'),
+                $this->getIdentityProvider()
             )
         );
 
@@ -137,15 +138,15 @@ final class ActionServiceProvider extends BaseServiceProvider
             Auth0::class,
             fn (): Auth0 => new Auth0(
                 [
-                    'domain' => $this->parameter('auth0.domain'),
-                    'clientId' => $this->parameter('auth0.client_id'),
-                    'clientSecret' => $this->parameter('auth0.client_secret'),
-                    'redirectUri' => $this->parameter('auth0.redirect_uri'),
+                    'domain' => $this->parameter($this->getIdentityProvider() . '.domain'),
+                    'clientId' => $this->parameter($this->getIdentityProvider() . '.client_id'),
+                    'clientSecret' => $this->parameter($this->getIdentityProvider() . '.client_secret'),
+                    'redirectUri' => $this->parameter($this->getIdentityProvider() . '.redirect_uri'),
                     'scope' => ['openid','email','profile','offline_access'],
                     'persistIdToken' => true,
                     'persistRefreshToken' => true,
-                    'tokenLeeway' => $this->parameter('auth0.id_token_leeway'),
-                    'cookieSecret' => $this->parameter('auth0.cookie_secret'),
+                    'tokenLeeway' => $this->parameter($this->getIdentityProvider() . '.id_token_leeway'),
+                    'cookieSecret' => $this->parameter($this->getIdentityProvider() . '.cookie_secret'),
                 ]
             )
         );
@@ -154,7 +155,7 @@ final class ActionServiceProvider extends BaseServiceProvider
             IsAllowedRefreshToken::class,
             fn (): IsAllowedRefreshToken => new IsAllowedRefreshToken(
                 $this->get(ConsumerReadRepositoryInterface::class),
-                (string)$this->parameter('auth0.allowed_refresh_permission')
+                (string)$this->parameter($this->getIdentityProvider() . '.allowed_refresh_permission')
             )
         );
 
@@ -177,5 +178,13 @@ final class ActionServiceProvider extends BaseServiceProvider
                 $this->get(IsAllowedRefreshToken::class)
             )
         );
+    }
+
+    private function getIdentityParameter(): string
+    {
+        if ($this->parameter('keycloak.enabled')) {
+            return 'keycloak';
+        }
+        return 'auth0';
     }
 }

--- a/app/ActionServiceProvider.php
+++ b/app/ActionServiceProvider.php
@@ -129,8 +129,7 @@ final class ActionServiceProvider extends BaseServiceProvider
                 new Client(),
                 $this->parameter($this->getIdentityProvider() . '.client_id'),
                 $this->parameter($this->getIdentityProvider() . '.client_secret'),
-                $this->parameter($this->getIdentityProvider() . '.domain'),
-                $this->getIdentityProvider()
+                $this->parameter($this->getIdentityProvider() . '.domain')
             )
         );
 
@@ -180,7 +179,7 @@ final class ActionServiceProvider extends BaseServiceProvider
         );
     }
 
-    private function getIdentityParameter(): string
+    private function getIdentityProvider(): string
     {
         if ($this->parameter('keycloak.enabled')) {
             return 'keycloak';

--- a/docker.md
+++ b/docker.md
@@ -1,0 +1,39 @@
+# JWTProvider with Docker
+
+## Prerequisite
+- Install Docker Desktop
+- appconfig: you'll have to clone [appconfig](https://github.com/cultuurnet/appconfig) in the same folder as where you will clone [udb3-backend](https://github.com/cultuurnet/udb3-backend)
+
+## Configure
+
+```
+$ make config
+```
+
+## Start
+
+### Docker
+
+Start the docker containers with the following command. Make sure to execute this inside the root of the project.
+```
+$ make up
+```
+
+### Composer packages
+
+To install all composer packages & migrate the database, run the following command:
+```
+$ make init
+```
+
+### CI
+
+To execute all CI tasks, run the following command:
+```
+$ make ci
+```
+
+### Debugging
+
+For local debugging purposes, a sample `jwt-example.php` is included in the `web`-folder. 
+To test it go to http://localhost:9999/jwt-example.php

--- a/docker/config.sh
+++ b/docker/config.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+DIR="../appconfig/files/udb3/docker/jwt-provider/"
+if [ -d "$DIR" ]; then
+  cp -R "$DIR"/* .
+else
+  echo "Error: missing appconfig see docker.md prerequisites to fix this."
+  exit 1
+fi

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -20,3 +20,4 @@ RUN a2enmod rewrite
 ENV APACHE_DOCUMENT_ROOT=/var/www/html/web
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+RUN echo '\nLimitRequestFieldSize 163840\nLimitRequestFields 1000\nLimitRequestLine 81900\n' >> /etc/apache2/apache2.conf

--- a/lib/tasks/jwt-provider/build.rake
+++ b/lib/tasks/jwt-provider/build.rake
@@ -5,6 +5,6 @@ namespace 'jwt-provider' do
   end
   desc "remove debug files"
   task :remove_debug_files do |task|
-      system('rm web/jwt-example*.php')
+      system('rm web/jwt-example.php')
   end
 end

--- a/lib/tasks/jwt-provider/build.rake
+++ b/lib/tasks/jwt-provider/build.rake
@@ -3,4 +3,8 @@ namespace 'jwt-provider' do
   task :build do |task|
     system('composer2 install --no-dev --ignore-platform-reqs --prefer-dist --optimize-autoloader') or exit 1
   end
+  desc "remove debug files"
+  task :remove_debug_files do |task|
+      system('rm web/jwt-example*.php')
+  end
 end

--- a/web/jwt-example.php
+++ b/web/jwt-example.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+session_start();
+
+if ($_SERVER['HTTP_HOST'] === 'localhost') {
+    header('response-code: 400');
+    die('Access denied.');
+}
+
+$url = urlencode('http://localhost:9999/jwt-example.php?apiKey=f3527f1c-210f-4075-99d3-ece98cf2b391');
+?>
+
+<ul>
+    <li><a href="http://localhost:9999/connect?destination=<?php echo $url?>">Connect without apiKey</a></li>
+    <li><a href="http://localhost:9999/connect?apiKey=f3527f1c-210f-4075-99d3-ece98cf2b391&destination=<?php echo $url?>">Connect with apiKey</a></li>
+    <li><a href="http://localhost:9999/logout?destination=<?php echo $url?>">Logout</a></li>
+    <li><a href="http://localhost:9999/logout-confirm">Logout confirm</a></li>
+    <li><a href="http://localhost:9999/refresh?apiKey=f3527f1c-210f-4075-99d3-ece98cf2b391&refresh=<?php echo $_GET['refresh'] ?? '' ?>">Refresh</a></li>
+</ul>
+
+    <style>
+        td {
+            word-wrap: anywhere;
+        }
+    </style>
+
+<?php
+if (!empty($_GET)) {
+    echo '<table border="1">';
+    echo '<tr><th>Parameter</th><th>Value</th></tr>';
+    foreach ($_GET as $key => $value) {
+
+        echo '<tr><td>' . htmlspecialchars($key) . '</td><td>' . htmlspecialchars($value) . '</td></tr>';
+    }
+    echo '</table>';
+}

--- a/web/jwt-example.php
+++ b/web/jwt-example.php
@@ -31,7 +31,6 @@ if (!empty($_GET)) {
     echo '<table border="1">';
     echo '<tr><th>Parameter</th><th>Value</th></tr>';
     foreach ($_GET as $key => $value) {
-
         echo '<tr><td>' . htmlspecialchars($key) . '</td><td>' . htmlspecialchars($value) . '</td></tr>';
     }
     echo '</table>';


### PR DESCRIPTION
### Added

- `web/jwt-example.php`: Sample file to test application on `docker`
- `docker.md`: Documentation to run the application
- `docker/config.sh`: shellscript to add configFiles

### Changed

- `Makefile`: added `config`
- `ActionServiceProvider`: Read `keycloak` or `auth0` depending on feature toggle
- `Dockefile`: because `refresh`-tokens are now bigger, the Apache limits need to be increased.

### Changed (Infrastructure)
- `build.rake`: delete debugTestfile

### Related PR

https://github.com/cultuurnet/appconfig/pull/685

---
Ticket: https://jira.publiq.be/browse/III-6207