### PR TITLE
III-6412 cleanup auth0 code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # JWT Provider
-Application that provides JSON Web Tokens from UiTID v2 (Auth0)
+Application that provides JSON Web Tokens from UiTID v2 (Keycloak)
 
 # Architecture 
 Code is split into Domain and Infrastructure. 
 
 Domain contains actions, domain services (interfaces), value objects, etc... Infrastructure contains technical
 capabilities to support the domain - mostly domain interface concrete implementation. The intention in this 
-division is to decouple from Auth0, at least to some extent so further changes in Auth provider can be 
+division is to decouple from Keycloak, at least to some extent so further changes in Auth provider can be 
 easier to implement.
 
 `web/index.php` is the **entry point** for the application. It will pass the request to the
@@ -16,5 +16,5 @@ with the rest of the Service Providers. Every route is tied to single action cla
 
 
 # Authentication flow
-jwt-provider service serves as a proxy between front end application and Auth0 service. 
+jwt-provider service serves as a proxy between front end application and Keycloak service. 
 ![image](.doc/auth-flow.png)

--- a/app/ActionServiceProvider.php
+++ b/app/ActionServiceProvider.php
@@ -98,16 +98,16 @@ final class ActionServiceProvider extends BaseServiceProvider
                 $this->get(Auth0::class),
                 new Authentication(
                     [
-                        'domain' => $this->parameter($this->getIdentityProvider() . '.domain'),
-                        'clientId' => $this->parameter($this->getIdentityProvider() . '.client_id'),
-                        'clientSecret' => $this->parameter($this->getIdentityProvider() . '.client_secret'),
-                        'cookieSecret' => $this->parameter($this->getIdentityProvider() . '.cookie_secret'),
+                        'domain' => $this->parameter('keycloak.domain'),
+                        'clientId' => $this->parameter('keycloak.client_id'),
+                        'clientSecret' => $this->parameter('keycloak.client_secret'),
+                        'cookieSecret' => $this->parameter('keycloak.cookie_secret'),
                     ]
                 ),
                 $this->get(ResponseFactoryInterface::class),
                 new UriFactory(),
-                $this->parameter($this->getIdentityProvider() . '.log_out_uri'),
-                $this->parameter($this->getIdentityProvider() . '.client_id')
+                $this->parameter('keycloak.log_out_uri'),
+                $this->parameter('keycloak.client_id')
             )
         );
 
@@ -127,9 +127,9 @@ final class ActionServiceProvider extends BaseServiceProvider
             RefreshServiceInterface::class,
             fn (): RefreshAuth0Adapter => new RefreshAuth0Adapter(
                 new Client(),
-                $this->parameter($this->getIdentityProvider() . '.client_id'),
-                $this->parameter($this->getIdentityProvider() . '.client_secret'),
-                $this->parameter($this->getIdentityProvider() . '.domain')
+                $this->parameter('keycloak.client_id'),
+                $this->parameter('keycloak.client_secret'),
+                $this->parameter('keycloak.domain')
             )
         );
 
@@ -137,15 +137,15 @@ final class ActionServiceProvider extends BaseServiceProvider
             Auth0::class,
             fn (): Auth0 => new Auth0(
                 [
-                    'domain' => $this->parameter($this->getIdentityProvider() . '.domain'),
-                    'clientId' => $this->parameter($this->getIdentityProvider() . '.client_id'),
-                    'clientSecret' => $this->parameter($this->getIdentityProvider() . '.client_secret'),
-                    'redirectUri' => $this->parameter($this->getIdentityProvider() . '.redirect_uri'),
+                    'domain' => $this->parameter('keycloak.domain'),
+                    'clientId' => $this->parameter('keycloak.client_id'),
+                    'clientSecret' => $this->parameter('keycloak.client_secret'),
+                    'redirectUri' => $this->parameter('keycloak.redirect_uri'),
                     'scope' => ['openid','email','profile','offline_access'],
                     'persistIdToken' => true,
                     'persistRefreshToken' => true,
-                    'tokenLeeway' => $this->parameter($this->getIdentityProvider() . '.id_token_leeway'),
-                    'cookieSecret' => $this->parameter($this->getIdentityProvider() . '.cookie_secret'),
+                    'tokenLeeway' => $this->parameter('keycloak.id_token_leeway'),
+                    'cookieSecret' => $this->parameter('keycloak.cookie_secret'),
                 ]
             )
         );
@@ -154,7 +154,7 @@ final class ActionServiceProvider extends BaseServiceProvider
             IsAllowedRefreshToken::class,
             fn (): IsAllowedRefreshToken => new IsAllowedRefreshToken(
                 $this->get(ConsumerReadRepositoryInterface::class),
-                (string)$this->parameter($this->getIdentityProvider() . '.allowed_refresh_permission')
+                (string)$this->parameter('keycloak.allowed_refresh_permission')
             )
         );
 

--- a/app/ActionServiceProvider.php
+++ b/app/ActionServiceProvider.php
@@ -25,7 +25,7 @@ use CultuurNet\UDB3\JwtProvider\Infrastructure\Repository\SessionClientInformati
 use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\ExtractClientInformationFromRequest;
 use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\ExtractLocaleFromRequest;
 use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\IsAllowedRefreshToken;
-use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\LoginAuth0Adapter;
+use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\LoginOAuthAdapter;
 use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\LogOutOAuthAdapter;
 use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\RefreshAuth0Adapter;
 use GuzzleHttp\Client;
@@ -118,7 +118,7 @@ final class ActionServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             LoginServiceInterface::class,
-            fn (): LoginAuth0Adapter => new LoginAuth0Adapter(
+            fn (): LoginOAuthAdapter => new LoginOAuthAdapter(
                 $this->get(Auth0::class)
             )
         );

--- a/app/ActionServiceProvider.php
+++ b/app/ActionServiceProvider.php
@@ -27,7 +27,7 @@ use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\ExtractLocaleFromRequest;
 use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\IsAllowedRefreshToken;
 use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\LoginOAuthAdapter;
 use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\LogOutOAuthAdapter;
-use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\RefreshAuth0Adapter;
+use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\RefreshOAuthAdapter;
 use GuzzleHttp\Client;
 use Slim\Psr7\Factory\UriFactory;
 
@@ -125,7 +125,7 @@ final class ActionServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             RefreshServiceInterface::class,
-            fn (): RefreshAuth0Adapter => new RefreshAuth0Adapter(
+            fn (): RefreshOAuthAdapter => new RefreshOAuthAdapter(
                 new Client(),
                 $this->parameter('keycloak.client_id'),
                 $this->parameter('keycloak.client_secret'),

--- a/app/ActionServiceProvider.php
+++ b/app/ActionServiceProvider.php
@@ -178,12 +178,4 @@ final class ActionServiceProvider extends BaseServiceProvider
             )
         );
     }
-
-    private function getIdentityProvider(): string
-    {
-        if ($this->parameter('keycloak.enabled')) {
-            return 'keycloak';
-        }
-        return 'auth0';
-    }
 }

--- a/app/ActionServiceProvider.php
+++ b/app/ActionServiceProvider.php
@@ -26,7 +26,7 @@ use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\ExtractClientInformationF
 use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\ExtractLocaleFromRequest;
 use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\IsAllowedRefreshToken;
 use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\LoginAuth0Adapter;
-use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\LogOutAuth0Adapter;
+use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\LogOutOAuthAdapter;
 use CultuurNet\UDB3\JwtProvider\Infrastructure\Service\RefreshAuth0Adapter;
 use GuzzleHttp\Client;
 use Slim\Psr7\Factory\UriFactory;
@@ -94,7 +94,7 @@ final class ActionServiceProvider extends BaseServiceProvider
 
         $this->addShared(
             LogOutServiceInterface::class,
-            fn (): LogOutAuth0Adapter => new LogOutAuth0Adapter(
+            fn (): LogOutOAuthAdapter => new LogOutOAuthAdapter(
                 $this->get(Auth0::class),
                 new Authentication(
                     [

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -13,7 +13,7 @@ jwt:
   keys:
     public:
       file: public.pem
-auth0:
+keycloak:
   domain:
   client_id:
   client_secret:

--- a/src/Infrastructure/Service/LogOutOAuthAdapter.php
+++ b/src/Infrastructure/Service/LogOutOAuthAdapter.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
-final class LogOutAuth0Adapter implements LogOutServiceInterface
+final class LogOutOAuthAdapter implements LogOutServiceInterface
 {
     private ResponseFactoryInterface $responseFactory;
 

--- a/src/Infrastructure/Service/LoginOAuthAdapter.php
+++ b/src/Infrastructure/Service/LoginOAuthAdapter.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\JwtProvider\Domain\Service\LoginServiceInterface;
 use Psr\Http\Message\ResponseInterface;
 use Slim\Psr7\Response;
 
-final class LoginAuth0Adapter implements LoginServiceInterface
+final class LoginOAuthAdapter implements LoginServiceInterface
 {
     private Auth0Interface $auth0;
 

--- a/src/Infrastructure/Service/RefreshOAuthAdapter.php
+++ b/src/Infrastructure/Service/RefreshOAuthAdapter.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\JwtProvider\Domain\Service\RefreshServiceInterface;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 
-final class RefreshAuth0Adapter implements RefreshServiceInterface
+final class RefreshOAuthAdapter implements RefreshServiceInterface
 {
     private Client $httpClient;
 

--- a/tests/Infrastructure/Service/LogOutOAuthAdapterTest.php
+++ b/tests/Infrastructure/Service/LogOutOAuthAdapterTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Slim\Psr7\Factory\UriFactory;
 
-final class LogOutAuth0AdapterTest extends TestCase
+final class LogOutOAuthAdapterTest extends TestCase
 {
     use ProphecyTrait;
 
@@ -28,7 +28,7 @@ final class LogOutAuth0AdapterTest extends TestCase
 
         $authentication->getLogoutLink('http://foo-bar.com', ['clientId' => 'client-id'])->willReturn($auth0LogOutUri);
 
-        $auth0adapter = new LogOutAuth0Adapter(
+        $logOutOAuthAdapter = new LogOutOAuthAdapter(
             $auth0->reveal(),
             $authentication->reveal(),
             new SlimResponseFactory(),
@@ -37,7 +37,7 @@ final class LogOutAuth0AdapterTest extends TestCase
             'client-id'
         );
 
-        $response = $auth0adapter->logout();
+        $response = $logOutOAuthAdapter->logout();
 
         $this->assertEquals(StatusCodeInterface::STATUS_MOVED_PERMANENTLY, $response->getStatusCode());
         $this->assertEquals($auth0LogOutUri, $response->getHeaderLine('Location'));

--- a/tests/Infrastructure/Service/LoginOAuthAdapterTest.php
+++ b/tests/Infrastructure/Service/LoginOAuthAdapterTest.php
@@ -25,7 +25,7 @@ final class LoginOAuthAdapterTest extends TestCase
     {
         $auth0 = $this->prophesize(Auth0Interface::class);
 
-        $auth0adapter = new LoginOAuthAdapter(
+        $loginOAuthAdapter = new LoginOAuthAdapter(
             $auth0->reveal()
         );
 
@@ -39,7 +39,7 @@ final class LoginOAuthAdapterTest extends TestCase
             ]
         )->shouldBeCalled();
 
-        $auth0adapter->redirectToLogin();
+        $loginOAuthAdapter->redirectToLogin();
     }
 
     /**
@@ -49,14 +49,14 @@ final class LoginOAuthAdapterTest extends TestCase
     {
         $auth0 = $this->prophesize(Auth0Interface::class);
 
-        $auth0adapter = new LoginOAuthAdapter(
+        $loginOAuthAdapter = new LoginOAuthAdapter(
             $auth0->reveal()
         );
 
         $auth0->getIdToken()->willReturn('token');
         $auth0->exchange()->willReturn(true);
 
-        $this->assertEquals('token', $auth0adapter->token());
+        $this->assertEquals('token', $loginOAuthAdapter->token());
     }
 
     /**
@@ -66,13 +66,13 @@ final class LoginOAuthAdapterTest extends TestCase
     {
         $auth0 = $this->prophesize(Auth0Interface::class);
 
-        $auth0adapter = new LoginOAuthAdapter(
+        $loginOAuthAdapter = new LoginOAuthAdapter(
             $auth0->reveal()
         );
 
         $auth0->getRefreshToken()->willReturn('refresh-token');
 
-        $this->assertEquals('refresh-token', $auth0adapter->refreshToken());
+        $this->assertEquals('refresh-token', $loginOAuthAdapter->refreshToken());
     }
 
     /**
@@ -84,7 +84,7 @@ final class LoginOAuthAdapterTest extends TestCase
     {
         $auth0 = $this->prophesize(Auth0Interface::class);
 
-        $auth0adapter = new LoginOAuthAdapter(
+        $loginOAuthAdapter = new LoginOAuthAdapter(
             $auth0->reveal()
         );
 
@@ -93,7 +93,7 @@ final class LoginOAuthAdapterTest extends TestCase
 
         $this->expectException(UnSuccessfulAuthException::class);
 
-        $auth0adapter->token();
+        $loginOAuthAdapter->token();
     }
 
     /**

--- a/tests/Infrastructure/Service/LoginOAuthAdapterTest.php
+++ b/tests/Infrastructure/Service/LoginOAuthAdapterTest.php
@@ -14,7 +14,7 @@ use Exception;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
-final class LoginAuth0AdapterTest extends TestCase
+final class LoginOAuthAdapterTest extends TestCase
 {
     use ProphecyTrait;
 
@@ -25,7 +25,7 @@ final class LoginAuth0AdapterTest extends TestCase
     {
         $auth0 = $this->prophesize(Auth0Interface::class);
 
-        $auth0adapter = new LoginAuth0Adapter(
+        $auth0adapter = new LoginOAuthAdapter(
             $auth0->reveal()
         );
 
@@ -49,7 +49,7 @@ final class LoginAuth0AdapterTest extends TestCase
     {
         $auth0 = $this->prophesize(Auth0Interface::class);
 
-        $auth0adapter = new LoginAuth0Adapter(
+        $auth0adapter = new LoginOAuthAdapter(
             $auth0->reveal()
         );
 
@@ -66,7 +66,7 @@ final class LoginAuth0AdapterTest extends TestCase
     {
         $auth0 = $this->prophesize(Auth0Interface::class);
 
-        $auth0adapter = new LoginAuth0Adapter(
+        $auth0adapter = new LoginOAuthAdapter(
             $auth0->reveal()
         );
 
@@ -84,7 +84,7 @@ final class LoginAuth0AdapterTest extends TestCase
     {
         $auth0 = $this->prophesize(Auth0Interface::class);
 
-        $auth0adapter = new LoginAuth0Adapter(
+        $auth0adapter = new LoginOAuthAdapter(
             $auth0->reveal()
         );
 


### PR DESCRIPTION
### Changed

- `README.md`: Removed info about `auth0`
- `config.dist.yml`: Replace `auth0` with `keycloak`
- `ActionServiceProvider`: remove `getIdentityProvider()` & always use `keycloak`, when fetching a value from config.
- Rename `LogOutAuth0Adapter` to `LogOutOAuthAdapter`
- Rename `LoginAuth0Adapter` to `LoginOAuthAdapter`
- Rename `RefreshAuth0Adapter` to `RefreshOAuthAdapter `

### Related PR

- https://github.com/cultuurnet/appconfig/pull/892

---
Ticket: https://jira.publiq.be/browse/III-6412