### PR TITLE
III-6659 enfore auth0 at minimum 8.3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php-http/message-factory": "^1.1",
         "laminas/laminas-httphandlerrunner": "^2.2",
         "sentry/sdk": "^4.0",
-        "auth0/auth0-php": "^8.3",
+        "auth0/auth0-php": "^8.3.1",
         "symfony/http-client": "^5.4",
         "hassankhan/config": "^3.1",
         "http-interop/http-factory-guzzle": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e1ca4e5a2d5a3ba7e29896334e1670e",
+    "content-hash": "2e1e2f5ec9b069066b5c82b85f5de59a",
     "packages": [
         {
             "name": "aura/session",


### PR DESCRIPTION
### Changed

- `composer`: enfore `auth0` at minimal `8.3.1`

### Note
The current version in `composer.lock` was already at `8.3.1`, which was unaffected by this critical vulnerability(https://github.com/advisories/GHSA-98j6-67v3-mw34). This commit merely prevents accidental downgrades.

---
Ticket: https://jira.publiq.be/browse/III-6659